### PR TITLE
Add training validation & evaluation utilities

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import json
 
 import torch
 
-from data_loader import ARCDataset
 from models import ARCModel, masked_cross_entropy
 from task_embeddings import TaskEmbeddingModule
-from utils import pad_grid
+from utils import pad_grid, unpad_grid
 
 
 def evaluate_task(
@@ -51,3 +50,65 @@ def evaluate_task(
         count += 1
     metrics = {k: v / count for k, v in metrics.items()}
     return metrics
+
+
+def predict_task(
+    model: ARCModel,
+    embeddings: TaskEmbeddingModule,
+    task_file: Path,
+    *,
+    adapt_steps: int = 50,
+    adapt_lr: float = 1e-2,
+    device: torch.device | None = None,
+) -> List[List[List[int]]]:
+    """Return predictions for the test pairs of ``task_file`` after adaptation."""
+    device = device or torch.device("cpu")
+    with open(task_file) as f:
+        data = json.load(f)
+    examples = []
+    for pair in data["train"]:
+        inp, in_mask = pad_grid(pair["input"])
+        out, out_mask = pad_grid(pair["output"])
+        examples.append((inp, out, in_mask, out_mask))
+    task_id = task_file.stem
+    adapted = embeddings.adapt_embedding(task_id, model, examples, steps=adapt_steps, lr=adapt_lr, device=device)
+    preds = []
+    for pair in data["test"]:
+        inp, in_mask = pad_grid(pair["input"])
+        inp = inp.unsqueeze(0).to(device)
+        in_mask = in_mask.unsqueeze(0).to(device)
+        logits, pred_mask = model(inp, adapted, in_mask)
+        grid = logits.argmax(dim=1).squeeze(0)
+        mask = pred_mask.squeeze(0) > 0.5
+        pred = unpad_grid(grid, mask)
+        preds.append(pred.cpu().tolist())
+    return preds
+
+
+def evaluate_split(
+    model: ARCModel,
+    embeddings: TaskEmbeddingModule,
+    root: str,
+    *,
+    split: str = "evaluation",
+    adapt_steps: int = 50,
+    adapt_lr: float = 1e-2,
+    device: torch.device | None = None,
+) -> Dict[str, float]:
+    """Evaluate ``model`` on all tasks of ``split``."""
+    device = device or torch.device("cpu")
+    data_dir = Path(root) / "data" / split
+    task_files = sorted(data_dir.glob("*.json"))
+    agg = defaultdict(float)
+    for task in task_files:
+        metrics = evaluate_task(
+            model,
+            embeddings,
+            task,
+            adapt_steps=adapt_steps,
+            adapt_lr=adapt_lr,
+            device=device,
+        )
+        for k, v in metrics.items():
+            agg[k] += v
+    return {k: v / len(task_files) for k, v in agg.items()}

--- a/notebooks/evaluate.ipynb
+++ b/notebooks/evaluate.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ARC-AGI-2 Evaluation\n",
+    "This notebook loads a trained model and evaluates it on the public evaluation tasks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os, torch\n",
+    "sys.path.append('..')\n",
+    "from models import ARCModel\n",
+    "from task_embeddings import TaskEmbeddingModule\n",
+    "from evaluation import evaluate_split, predict_task\n",
+    "\n",
+    "ckpt = torch.load('../arc_model.pt', map_location='cpu')\n",
+    "model = ARCModel()\n",
+    "model.load_state_dict(ckpt['model'])\n",
+    "task_ids = list(ckpt['task_ids'].keys())\n",
+    "embeddings = TaskEmbeddingModule(task_ids)\n",
+    "embeddings.load_state_dict(ckpt['embeddings'])\n",
+    "model.eval()\n",
+    "embeddings.eval()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics = evaluate_split(model, embeddings, root='..')\n",
+    "print(metrics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "eval_dir = Path('..') / 'data' / 'evaluation'\n",
+    "task_path = sorted(eval_dir.glob('*.json'))[0]\n",
+    "preds = predict_task(model, embeddings, task_path)\n",
+    "print('Predictions for', task_path.stem)\n",
+    "for grid in preds:\n",
+    "    for row in grid:\n",
+    "        print(row)\n",
+    "    print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "nbconvert_exporter": "python",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- save a validation split and save model weights after training
- implement task prediction and dataset evaluation helpers
- provide a notebook demo for evaluating models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710b3af91c832dbf3c55e7ecee6d38