### PR TITLE
Add evaluation scoring and notebook visualization

### DIFF
--- a/notebooks/evaluate.ipynb
+++ b/notebooks/evaluate.ipynb
@@ -46,16 +46,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "eval_dir = Path('..') / 'data' / 'evaluation'\n",
-    "task_path = sorted(eval_dir.glob('*.json'))[0]\n",
-    "preds = predict_task(model, embeddings, task_path)\n",
-    "print('Predictions for', task_path.stem)\n",
-    "for grid in preds:\n",
-    "    for row in grid:\n",
-    "        print(row)\n",
-    "    print()"
-   ]
+  "from pathlib import Path\n",
+  "from utils import visualize_grid\n",
+  "eval_dir = Path('..') / 'data' / 'evaluation'\n",
+  "task_path = sorted(eval_dir.glob('*.json'))[0]\n",
+  "preds = predict_task(model, embeddings, task_path)\n",
+  "print('Predictions for', task_path.stem)\n",
+  "for grid in preds:\n",
+  "    visualize_grid(torch.tensor(grid))"
+]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- add `score_split` to compute prediction accuracy
- report evaluation score every 10 epochs in `train`
- include evaluation tasks in embedding module without training them
- visualize predictions from embedding adaptation in the notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710ff7b9ec832d9560e4c9b45946df